### PR TITLE
Muse proto mute setting incorrect

### DIFF
--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -39,7 +39,9 @@ media_player:
     i2s_dout_pin: GPIO26
     i2s_bclk_pin: GPIO5
     mode: mono
-    mute_pin: GPIO21
+    mute_pin: 
+      number: GPIO21
+      inverted: true
 
 binary_sensor:
   - platform: gpio

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -39,14 +39,7 @@ media_player:
     i2s_dout_pin: GPIO26
     i2s_bclk_pin: GPIO5
     mode: mono
-
-switch:
-  - platform: gpio
-    name: "${friendly_name} Mute"
-    restore_mode: ALWAYS_ON
-    pin:
-      number: GPIO21
-      inverted: false
+    mute: GPIO21
 
 binary_sensor:
   - platform: gpio

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -42,11 +42,11 @@ media_player:
 
 switch:
   - platform: gpio
-    name: "${friendly_name} Power"
+    name: "${friendly_name} Mute"
     restore_mode: ALWAYS_ON
     pin:
       number: GPIO21
-      inverted: true
+      inverted: false
 
 binary_sensor:
   - platform: gpio

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -39,7 +39,7 @@ media_player:
     i2s_dout_pin: GPIO26
     i2s_bclk_pin: GPIO5
     mode: mono
-    mute: GPIO21
+    mute_pin: GPIO21
 
 binary_sensor:
   - platform: gpio


### PR DESCRIPTION
GPIO pin 21 is for mute and mine would only output sounds with the switch off, this corrects that.