### PR TITLE
Added battery sensor

### DIFF
--- a/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio-muse-luxe.yaml
@@ -58,16 +58,16 @@ sensor:
    pin: GPIO33
    name: ${name} Battery
    icon: "mdi:battery-outline"
-   update_interval: 60s
-   accuracy_decimals: 2
+   update_interval: 15s
+   accuracy_decimals: 3
    attenuation: 11db
    raw: true
    filters:
     - multiply: 0.00173913 # 2300 -> 4, for attenuation 11db, based on Olivier's code
-    - sliding_window_moving_average:
-         window_size: 10
-         send_every: 2
-    - delta: 0.01
+    - exponential_moving_average:
+        alpha: 0.2
+        send_every: 2
+    - delta: 0.002
 
 binary_sensor:
   - platform: gpio

--- a/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio-muse-luxe.yaml
@@ -53,6 +53,22 @@ media_player:
 
 es8388:
 
+sensor:
+ - platform: adc
+   pin: GPIO33
+   name: ${name} Battery
+   icon: "mdi:battery-outline"
+   update_interval: 60s
+   accuracy_decimals: 2
+   attenuation: 11db
+   raw: true
+   filters:
+    - multiply: 0.00173913 # 2300 -> 4, for attenuation 11db, based on Olivier's code
+    - sliding_window_moving_average:
+         window_size: 10
+         send_every: 2
+    - delta: 0.01
+
 binary_sensor:
   - platform: gpio
     pin:

--- a/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio-muse-luxe.yaml
@@ -58,6 +58,9 @@ sensor:
    pin: GPIO33
    name: ${name} Battery
    icon: "mdi:battery-outline"
+   device_class: voltage
+   state_class: measurement
+   unit_of_measurement: V
    update_interval: 15s
    accuracy_decimals: 3
    attenuation: 11db


### PR DESCRIPTION
When asking Olivier Ros about the possibility of a battery sensor in the Muse, I was told the hardware is already set up for this and got pointers to his code. With that information I attempted an implementation for the ESPHome version.

Everything works on my muse, however, as indicated in my initial comment, the readings are quite a bit off (max ~4.5V).

For now I adjust the my automation thresholds according to the discharge curve, at some point a more thorough calibration will follow ...

