### PR TITLE
Add id property to light

### DIFF
--- a/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo.yaml
@@ -51,7 +51,7 @@ binary_sensor:
 
 light:
   - platform: fastled_clockless
-    id: ${name}
+    id: led
     name: ${friendly_name}
     pin: GPIO27
     chipset: SK6812

--- a/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo.yaml
@@ -51,6 +51,7 @@ binary_sensor:
 
 light:
   - platform: fastled_clockless
+    id: ${name}
     name: ${friendly_name}
     pin: GPIO27
     chipset: SK6812


### PR DESCRIPTION
If a user wants to add a lambda to change the light color, the light needs an id.