### PR TITLE
Break out I2S audio component

### DIFF
--- a/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo.yaml
@@ -34,13 +34,13 @@ i2s_audio:
   i2s_lrclk_pin: GPIO33
   i2s_bclk_pin: GPIO19
 
-media_player:
+microphone:
   - platform: i2s_audio
-    id: media_out
-    name: ${friendly_name}
-    dac_type: external
-    i2s_dout_pin: GPIO22
-    mode: mono
+    id: echo_microphone
+    i2s_din_pin: GPIO23
+
+voice_assistant:
+  microphone: echo_microphone
 
 binary_sensor:
   - platform: gpio
@@ -48,8 +48,21 @@ binary_sensor:
       number: GPIO39
       inverted: true
     name: ${friendly_name} Button
+    id: echo_button
+    on_press:
+      - voice_assistant.start:
+    on_release:
+      - voice_assistant.stop:
     on_click:
       - media_player.toggle: media_out
+
+media_player:
+  - platform: i2s_audio
+    id: media_out
+    name: ${friendly_name}
+    dac_type: external
+    i2s_dout_pin: GPIO22
+    mode: mono
 
 light:
   - platform: fastled_clockless

--- a/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo.yaml
@@ -30,14 +30,16 @@ captive_portal:
 
 improv_serial:
 
+i2s_audio:
+  i2s_lrclk_pin: GPIO33
+  i2s_bclk_pin: GPIO19
+
 media_player:
   - platform: i2s_audio
     id: media_out
     name: ${friendly_name}
     dac_type: external
-    i2s_lrclk_pin: GPIO33
     i2s_dout_pin: GPIO22
-    i2s_bclk_pin: GPIO19
     mode: mono
 
 binary_sensor:

--- a/m5stack-atom-speaker-kit.yaml
+++ b/m5stack-atom-speaker-kit.yaml
@@ -30,14 +30,16 @@ captive_portal:
 
 improv_serial:
 
+i2s_audio:
+    i2s_lrclk_pin: GPIO21
+    i2s_bclk_pin: GPIO22
+
 media_player:
   - platform: i2s_audio
     id: media_out
     name: ${friendly_name}
     dac_type: external
-    i2s_lrclk_pin: GPIO21
     i2s_dout_pin: GPIO25
-    i2s_bclk_pin: GPIO22
     mode: mono
 
 binary_sensor:

--- a/m5stack-atom-speaker-kit.yaml
+++ b/m5stack-atom-speaker-kit.yaml
@@ -31,7 +31,7 @@ captive_portal:
 improv_serial:
 
 i2s_audio:
-    i2s_lrclk_pin: GPIO21
+  - i2s_lrclk_pin: GPIO21
     i2s_bclk_pin: GPIO22
 
 media_player:

--- a/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio-muse-luxe.yaml
@@ -39,13 +39,15 @@ external_components:
     components: [es8388]
     refresh: 0s
 
+i2s_audio:
+  - i2s_lrclk_pin: GPIO25
+    i2s_bclk_pin: GPIO5
+
 media_player:
   - platform: i2s_audio
     name: ${friendly_name}
     dac_type: external
-    i2s_lrclk_pin: GPIO25
     i2s_dout_pin: GPIO26
-    i2s_bclk_pin: GPIO5
     mode: stereo
     mute_pin:
       number: GPIO21

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -30,14 +30,16 @@ captive_portal:
 
 improv_serial:
 
+i2s_audio:
+  - i2s_lrclk_pin: GPIO25
+    i2s_bclk_pin: GPIO5
+
 media_player:
   - platform: i2s_audio
     id: media_out
     name: ${friendly_name}
     dac_type: external
-    i2s_lrclk_pin: GPIO25
     i2s_dout_pin: GPIO26
-    i2s_bclk_pin: GPIO5
     mode: mono
     mute_pin:
       number: GPIO21


### PR DESCRIPTION
Updating an Atom echo with the config on Github breaks, because I2S audio has not been pulled out in the config. This PR fixes that...