### PR TITLE
Voice assistant muse proto

### DIFF
--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -6,10 +6,10 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
-  name_add_mac_suffix: true
   project:
     name: raspiaudio.muse-proto
     version: "1.0"
+  min_version: 2023.5.0
 
 esp32:
   board: esp-wrover-kit
@@ -19,6 +19,11 @@ esp32:
 logger:
 api:
 ota:
+
+external_components:
+  - source: github://pr#4871 # I2S microphone channel https://github.com/esphome/esphome/pull/4871
+    components: [i2s_audio]
+    refresh: 0s
 
 dashboard_import:
   package_import_url: github://esphome/media-players/raspiaudio-muse-proto.yaml@main
@@ -35,6 +40,21 @@ i2s_audio:
   - i2s_lrclk_pin: GPIO25
     i2s_bclk_pin: GPIO5
 
+microphone:
+  - platform: i2s_audio
+    id: board_microphone
+    channel: left
+    i2s_din_pin: GPIO35
+    adc_type: external
+    pdm: false
+
+speaker:
+  - platform: i2s_audio
+    id: board_external_speakers
+    dac_type: external
+    i2s_dout_pin: GPIO26
+    mode: mono
+
 media_player:
   - platform: i2s_audio
     id: media_out
@@ -46,6 +66,46 @@ media_player:
       number: GPIO21
       inverted: true
 
+voice_assistant:
+  microphone: board_microphone
+  speaker: board_external_speakers
+  on_start:
+    - light.turn_on:
+        id: board_led
+        blue: 100%
+        red: 0%
+        green: 0%
+        effect: none
+  on_tts_start:
+    - light.turn_on:
+        id: board_led
+        blue: 60%
+        red: 20%
+        green: 20%
+        effect: none
+  on_tts_end:
+    - light.turn_on:
+        id: board_led
+        blue: 60%
+        red: 20%
+        green: 20%
+        effect: pulse
+  on_end:
+    - delay: 1s
+    - wait_until:
+        not:
+          speaker.is_playing:
+    - light.turn_off: board_led
+  on_error:
+    - light.turn_on:
+        id: board_led
+        blue: 0%
+        red: 100%
+        green: 0%
+        effect: none
+    - delay: 1s
+    - light.turn_off: board_led
+
 binary_sensor:
   - platform: gpio
     pin:
@@ -54,14 +114,35 @@ binary_sensor:
       mode:
         input: true
         pullup: true
-    name: Button
-    on_click:
-      - media_player.toggle: media_out
+    name: ${friendly_name} Action
+    on_multi_click:
+      - timing:
+          - ON FOR AT MOST 350ms
+          - OFF FOR AT LEAST 10ms
+        then:
+          - media_player.toggle: media_out
+      - timing:
+          - ON FOR AT LEAST 350ms
+        then:
+          - voice_assistant.start:
+      - timing:
+          - ON FOR AT LEAST 350ms
+          - OFF FOR AT LEAST 10ms
+        then:
+          - voice_assistant.stop:
 
 light:
-  - platform: fastled_clockless
+  - platform: esp32_rmt_led_strip
+    id: board_led
     name: None
+    disabled_by_default: true
     pin: GPIO22
-    chipset: SK6812
+    default_transition_length: 0s
+    chipset: WS2812
     num_leds: 1
     rgb_order: grb
+    rmt_channel: 0
+    effects:
+      - pulse:
+          transition_length: 250ms
+          update_interval: 250ms

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -10,7 +10,7 @@ esphome:
   project:
     name: raspiaudio.muse-proto
     version: "1.0"
-  min_version: 2023.5.0
+  min_version: 2023.5.3
 
 esp32:
   board: esp-wrover-kit
@@ -20,11 +20,6 @@ esp32:
 logger:
 api:
 ota:
-
-external_components:
-  - source: github://pr#4871 # I2S microphone channel https://github.com/esphome/esphome/pull/4871
-    components: [i2s_audio]
-    refresh: 0s
 
 dashboard_import:
   package_import_url: github://esphome/media-players/raspiaudio-muse-proto.yaml@main

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -6,6 +6,7 @@ substitutions:
 esphome:
   name: ${name}
   friendly_name: ${friendly_name}
+  name_add_mac_suffix: true
   project:
     name: raspiaudio.muse-proto
     version: "1.0"

--- a/raspiaudio-muse-proto.yaml
+++ b/raspiaudio-muse-proto.yaml
@@ -110,7 +110,7 @@ binary_sensor:
       mode:
         input: true
         pullup: true
-    name: ${friendly_name} Action
+    name: Action
     on_multi_click:
       - timing:
           - ON FOR AT MOST 350ms


### PR DESCRIPTION
Add voice assistant for Raspiaudio Muse Proto.

Needs https://github.com/esphome/esphome/pull/4871 to change the channel, the Muse Proto uses left channel.