### PR TITLE
Stop media player before starting voice assistant in m5stack-atom-echo

### DIFF
--- a/m5stack-atom-echo.yaml
+++ b/m5stack-atom-echo.yaml
@@ -99,6 +99,11 @@ binary_sensor:
       - timing:
           - ON FOR AT LEAST 350ms
         then:
+          - if:
+              condition:
+                media_player.is_playing: media_out
+              then:
+                - media_player.stop: media_out
           - voice_assistant.start:
       - timing:
           - ON FOR AT LEAST 350ms


### PR DESCRIPTION
Stop playing any media before starting listening.
When long-pressing the button while a command result is playing, STT fails because of the noise from the internal speaker at the same time we talk.
If nothing is playing, voice_assistant starts directly.
