### PR TITLE
Disable auto firmware building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,6 @@ name: Build
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
The source and generation of our media-players has moved to https://github.com/esphome/firmware and https://esphome.io/projects?type=media