### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/build.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     with:
       files: |
         m5stack/m5stack-atom-echo.factory.yaml
@@ -34,7 +34,7 @@ jobs:
     name: Upload to R2
     needs:
       - build-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     with:
       directory: media-player
     secrets: inherit
@@ -42,7 +42,7 @@ jobs:
   upload-to-release:
     name: Upload to Release
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     needs:
       - build-firmware
     with:
@@ -51,7 +51,7 @@ jobs:
   promote-prod:
     name: Promote to Production
     if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.10.0
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@e7eee2a828517c042794a831f75310959fbf2a16  # 2025.10.0
     needs:
       - upload-to-r2
     with:

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -16,7 +16,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5.0.1
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
         with:
           pr-inactive-days: "1"
           pr-lock-reason: ""

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10.1.0
+      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008  # v10.1.0
         with:
           stale-issue-message: 'As there has been no activity on this issue for 30 days, I am marking it as stale. If you think this is a mistake, please comment below and I will remove the stale label.'
           close-issue-message: 'This issue has been closed due to inactivity. If you think this is a mistake, please comment below.'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out configuration from GitHub
-        uses: actions/checkout@v6.0.0
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
       - name: 🚀 Run yamllint
         run: yamllint --strict .


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

Closes #90


## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
