### PR TITLE
Fix firmware build for ESPHome 2026.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         onju-voice/onju-voice.factory.yaml
         raspiaudio/raspiaudio-muse-luxe.factory.yaml
         raspiaudio/raspiaudio-muse-proto.factory.yaml
-      esphome-version: 2025.11.3
+      esphome-version: 2026.5.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/m5stack/m5stack-atom-echo.yaml
+++ b/m5stack/m5stack-atom-echo.yaml
@@ -117,6 +117,8 @@ media_player:
     name: None
     announcement_pipeline:
       speaker: echo_speaker
+      format: WAV
+    buffer_size: 6000
 
 light:
   - platform: esp32_rmt_led_strip

--- a/m5stack/m5stack-atom-echo.yaml
+++ b/m5stack/m5stack-atom-echo.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: m5stack-atom-echo
   friendly_name: M5Stack Atom Echo
-  min_version: 2024.6.0
+  min_version: 2025.5.0
   name_add_mac_suffix: true
 
 esp32:
   board: m5stack-atom
   framework:
-    type: arduino
+    type: esp-idf
 
 logger:
 api:

--- a/m5stack/m5stack-atom-echo.yaml
+++ b/m5stack/m5stack-atom-echo.yaml
@@ -104,13 +104,19 @@ binary_sensor:
         then:
           - voice_assistant.stop:
 
-media_player:
+speaker:
   - platform: i2s_audio
-    id: media_out
-    name: None
+    id: echo_speaker
     dac_type: external
     i2s_dout_pin: GPIO22
-    mode: mono
+    channel: mono
+
+media_player:
+  - platform: speaker
+    id: media_out
+    name: None
+    announcement_pipeline:
+      speaker: echo_speaker
 
 light:
   - platform: esp32_rmt_led_strip

--- a/m5stack/m5stack-atom-speaker-kit.yaml
+++ b/m5stack/m5stack-atom-speaker-kit.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: m5stack-atom-speaker-kit
   friendly_name: M5Stack Atom Speaker Kit
-  min_version: 2024.6.0
+  min_version: 2025.5.0
   name_add_mac_suffix: true
 
 esp32:
   board: m5stack-atom
   framework:
-    type: arduino
+    type: esp-idf
 
 logger:
 api:

--- a/m5stack/m5stack-atom-speaker-kit.yaml
+++ b/m5stack/m5stack-atom-speaker-kit.yaml
@@ -26,13 +26,19 @@ i2s_audio:
     i2s_lrclk_pin: GPIO21
     i2s_bclk_pin: GPIO22
 
-media_player:
+speaker:
   - platform: i2s_audio
-    id: media_out
-    name: None
+    id: speaker_out
     dac_type: external
     i2s_dout_pin: GPIO25
-    mode: mono
+    channel: mono
+
+media_player:
+  - platform: speaker
+    id: media_out
+    name: None
+    announcement_pipeline:
+      speaker: speaker_out
 
 binary_sensor:
   - platform: gpio

--- a/m5stack/m5stack-atom-speaker-kit.yaml
+++ b/m5stack/m5stack-atom-speaker-kit.yaml
@@ -39,6 +39,8 @@ media_player:
     name: None
     announcement_pipeline:
       speaker: speaker_out
+      format: WAV
+    buffer_size: 6000
 
 binary_sensor:
   - platform: gpio

--- a/onju-voice/onju-voice.yaml
+++ b/onju-voice/onju-voice.yaml
@@ -1,7 +1,7 @@
 esphome:
   name: onju-voice
   friendly_name: Onju Voice
-  min_version: 2024.6.0
+  min_version: 2025.5.0
   name_add_mac_suffix: true
   on_boot:
     then:
@@ -35,7 +35,7 @@ esphome:
 esp32:
   board: esp32-s3-devkitc-1
   framework:
-    type: arduino
+    type: esp-idf
 
 logger:
 

--- a/onju-voice/onju-voice.yaml
+++ b/onju-voice/onju-voice.yaml
@@ -88,16 +88,19 @@ i2s_audio:
     i2s_lrclk_pin: GPIO13
     i2s_bclk_pin: GPIO18
 
-media_player:
+speaker:
   - platform: i2s_audio
-    name: None
-    id: onju_out
+    id: onju_speaker
     dac_type: external
     i2s_dout_pin: GPIO12
-    mode: mono
-    mute_pin:
-      number: GPIO21
-      inverted: true
+    channel: mono
+
+media_player:
+  - platform: speaker
+    name: None
+    id: onju_out
+    announcement_pipeline:
+      speaker: onju_speaker
 
 microphone:
   - platform: i2s_audio
@@ -460,6 +463,13 @@ script:
           }
 
 switch:
+  - platform: gpio
+    id: amplifier_enable
+    pin:
+      number: GPIO21
+      inverted: true
+    restore_mode: RESTORE_DEFAULT_ON
+    internal: true
   - platform: template
     name: Use Wake Word
     id: use_wake_word

--- a/raspiaudio/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio/raspiaudio-muse-luxe.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: raspiaudio-muse-luxe
   friendly_name: RaspiAudio Muse Luxe
-  min_version: 2024.6.0
+  min_version: 2025.5.0
   name_add_mac_suffix: true
 
 esp32:
   board: esp-wrover-kit
   framework:
-    type: arduino
+    type: esp-idf
 
 logger:
 api:
@@ -182,7 +182,7 @@ switch:
     internal: true
 
 light:
-  - platform: fastled_clockless
+  - platform: esp32_rmt_led_strip
     name: None
     id: top_led
     pin: GPIO22

--- a/raspiaudio/raspiaudio-muse-luxe.yaml
+++ b/raspiaudio/raspiaudio-muse-luxe.yaml
@@ -38,16 +38,19 @@ i2s_audio:
     i2s_lrclk_pin: GPIO25
     i2s_bclk_pin: GPIO5
 
-media_player:
+speaker:
   - platform: i2s_audio
-    name: None
-    id: luxe_out
+    id: luxe_speaker
     dac_type: external
     i2s_dout_pin: GPIO26
-    mode: stereo
-    mute_pin:
-      number: GPIO21
-      inverted: true
+    channel: stereo
+
+media_player:
+  - platform: speaker
+    name: None
+    id: luxe_out
+    announcement_pipeline:
+      speaker: luxe_speaker
 
 microphone:
   - platform: i2s_audio
@@ -168,6 +171,15 @@ binary_sensor:
           - OFF FOR AT LEAST 10ms
         then:
           - voice_assistant.stop:
+
+switch:
+  - platform: gpio
+    id: amplifier_enable
+    pin:
+      number: GPIO21
+      inverted: true
+    restore_mode: RESTORE_DEFAULT_ON
+    internal: true
 
 light:
   - platform: fastled_clockless

--- a/raspiaudio/raspiaudio-muse-proto.yaml
+++ b/raspiaudio/raspiaudio-muse-proto.yaml
@@ -38,27 +38,28 @@ speaker:
   - platform: i2s_audio
     id: board_external_speakers
     dac_type: external
-    i2s_dout_pin:
-      number: GPIO26
-      allow_other_uses: true
+    i2s_dout_pin: GPIO26
     channel: mono
 
 media_player:
-  - platform: i2s_audio
+  - platform: speaker
     id: media_out
     name: None
-    dac_type: external
-    i2s_dout_pin:
-      number: GPIO26
-      allow_other_uses: true
-    mode: mono
-    mute_pin:
+    announcement_pipeline:
+      speaker: board_external_speakers
+
+switch:
+  - platform: gpio
+    id: amplifier_enable
+    pin:
       number: GPIO21
       inverted: true
+    restore_mode: RESTORE_DEFAULT_ON
+    internal: true
 
 voice_assistant:
   microphone: board_microphone
-  speaker: board_external_speakers
+  media_player: media_out
   on_start:
     - light.turn_on:
         id: board_led
@@ -84,7 +85,7 @@ voice_assistant:
     - delay: 1s
     - wait_until:
         not:
-          speaker.is_playing:
+          media_player.is_playing: media_out
     - light.turn_off: board_led
   on_error:
     - light.turn_on:

--- a/raspiaudio/raspiaudio-muse-proto.yaml
+++ b/raspiaudio/raspiaudio-muse-proto.yaml
@@ -1,13 +1,13 @@
 esphome:
   name: raspiaudio-muse-proto
   friendly_name: RaspiAudio Muse Proto
-  min_version: 2024.9.0
+  min_version: 2025.5.0
   name_add_mac_suffix: true
 
 esp32:
   board: esp-wrover-kit
   framework:
-    type: arduino
+    type: esp-idf
 
 logger:
 api:


### PR DESCRIPTION
PR #82 bumps ESPHome to 2026.5.3, but that release removed the `i2s_audio` media player platform, so the firmware build fails for all five devices. This branch includes that version bump and migrates every device to the speaker media player so the build passes and audio works again.