### PR TITLE
Migrate lock workflow to shared esphome workflow

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,14 +14,8 @@ concurrency:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771  # v5.0.1
-        with:
-          pr-inactive-days: "1"
-          pr-lock-reason: ""
-          exclude-any-pr-labels: keep-open
-
-          issue-inactive-days: "1"
-          issue-lock-reason: ""
-          exclude-any-issue-labels: keep-open
+    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      pr-close-days: 1
+      issue-close-days: 1
+      exclude-label: keep-open


### PR DESCRIPTION
Replaces the direct `dessant/lock-threads` step in `lock.yml` with the shared `esphome/workflows/.github/workflows/lock.yml` reusable workflow, matching the pattern already used in `esphome/firmware` and `esphome/bluetooth-proxies`.

The call is pinned to the same `2026.4.1` SHA already used by `build.yml`, so the existing dependabot `shared-workflows` group keeps it up to date. Settings are preserved: PRs and issues lock 1 day after close, `keep-open` label excluded, no lock reason. Note the shared workflow locks based on time since *closed* rather than time since last activity, the same semantic shift the other repos accepted when migrating.