### PR TITLE
Modernise repository to match the ready-made project template

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,13 @@
 {
   "name": "ESPHome - Media Players",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10",
+  "image": "mcr.microsoft.com/devcontainers/python:3.13",
   "postCreateCommand": "pip3 install esphome",
+  "runArgs": ["--device=/dev/bus/usb", "--privileged"],
+  "features": { "ghcr.io/devcontainers/features/github-cli": {} },
   "customizations": {
     "vscode": {
-      "settings": {
-        "esphome.validator": "local"
-      },
-      "extensions": [
-        "ESPHome.esphome-vscode"
-      ]
+      "settings": { "esphome.validator": "local" },
+      "extensions": ["ESPHome.esphome-vscode"]
     }
   }
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Media Players Bug Report
+description: |-
+  Report an issue with the Media Players firmware provided by this repository,
+  the web installer and the provided OTA updates.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This issue form is for reporting bugs with the Media Players firmware that is compiled and released
+        from this repository. This includes flashing the firmware from the ESPHome projects page and the OTA updates that are provided.
+
+        **This is NOT for:**
+        - Reporting issues with ESPHome itself. Please use the [ESPHome issue tracker](https://github.com/esphome/esphome/issues)
+        - Requesting new device support. We only add new devices we have tested and are happy to recommend.
+
+        If you have taken control of the device in the ESPHome Builder, please report the issue in the main [ESPHome issue tracker][issues].
+
+        [issues]: https://github.com/esphome/esphome/issues
+
+  - type: textarea
+    validations:
+      required: true
+    id: problem
+    attributes:
+      label: The problem
+      description: >-
+        Describe the issue you are experiencing here to communicate to the
+        maintainers. Tell us what you were trying to do and what happened.
+
+        Provide a clear and concise description of what the problem is.
+
+  - type: dropdown
+    validations:
+      required: true
+    id: device
+    attributes:
+      label: Which device are you using?
+      options:
+        - m5stack-atom-echo
+        - m5stack-atom-speaker-kit
+        - onju-voice
+        - raspiaudio-muse-luxe
+        - raspiaudio-muse-proto
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Firmware Version
+      description: >
+        The version of the installed firmware. This is **NOT** the ESPHome version, but is in the format `26.7.1` for example.
+
+  - type: textarea
+    id: logs
+    validations:
+      required: true
+    attributes:
+      label: Logs
+      description: For example, error messages or stack traces. Serial logs from the USB port are much more useful than WiFi logs.
+      render: txt
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional information
+      description: >
+        If you have any additional information for us, use the field below.
+        Please note, you can attach screenshots or screen recordings here, by
+        dragging and dropping files in the field below.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Issue after taking control of the firmware provided here
+    url: https://github.com/esphome/esphome/issues
+    about: |-
+      Please search for or create an issue in the main ESPHome issue tracker
+      if you have taken control/adopted your device in the ESPHome Builder.
+  - name: Feature Request / Device Request
+    url: https://github.com/orgs/esphome/discussions
+    about: |-
+      Create a discussion on the ESPHome discussion board if you have a
+      feature request or device request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+# What does this implement/fix?
+
+<!-- Quick description and explanation of changes -->
+
+## Types of changes
+
+<!-- Release notes are generated from PR labels, so apply the matching label as well. -->
+
+- [ ] Bugfix (non-breaking change which fixes an issue) — label: `bugfix`
+- [ ] New device (adds a configuration for a new device) — label: `new-device`
+- [ ] Enhancement (non-breaking change which improves an existing configuration) — label: `enhancement`
+- [ ] Breaking change (fix or change that alters existing behaviour, e.g. renamed entities or changed pins) — label: `breaking-change`
+- [ ] Dependency update (actions, reusable workflows or ESPHome version) — label: `dependencies`
+- [ ] Other
+
+**Related issue (if applicable):**
+
+- fixes <link to issue>
+
+## Checklist
+
+- [ ] The configuration compiles and has been tested on the actual device.
+- [ ] `yamllint --strict .` passes.
+
+If a device configuration was added or renamed:
+
+- [ ] The device directory contains both `<device>.yaml` (core config) and `<device>.factory.yaml` (factory wrapper).
+- [ ] `dashboard_import.package_import_url` points to the core YAML in this repository.
+- [ ] `update.source` points to the correct `https://firmware.esphome.io/<directory>/<device>/manifest.json` URL.
+- [ ] The factory YAML is named `<device>.factory.yaml` so CI picks it up automatically.
+- [ ] The device is listed in the dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`.
+- [ ] The README is updated if it lists supported devices.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "New Devices"
+    label: "new-device"
+  - title: "Enhancements"
+    label: "enhancement"
+  - title: "Bug Fixes"
+    label: "bugfix"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+# Version is calculated externally (calver YY.M.N) and passed in as an input,
+# so the version-resolver here is unused. The workflow overrides
+# `name`, `tag`, and `version`.
+
+template: |
+  > [!CAUTION]
+  > **DO NOT PUBLISH THIS RELEASE YET!**
+  > Build assets have not been uploaded. Wait for the build workflow to complete
+  > and this notice to be removed before publishing.
+  <!-- ASSETS_PENDING -->
+
+  ## What's Changed
+
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,17 +2,22 @@ name-template: "$RESOLVED_VERSION"
 tag-template: "$RESOLVED_VERSION"
 categories:
   - title: "Breaking Changes"
-    label: "breaking-change"
+    when:
+      label: "breaking-change"
   - title: "New Devices"
-    label: "new-device"
+    when:
+      label: "new-device"
   - title: "Enhancements"
-    label: "enhancement"
+    when:
+      label: "enhancement"
   - title: "Bug Fixes"
-    label: "bugfix"
+    when:
+      label: "bugfix"
   - title: "Dependencies"
     collapse-after: 1
-    labels:
-      - "dependencies"
+    when:
+      labels:
+        - "dependencies"
 
 # Version is calculated externally (calver YY.M.N) and passed in as an input,
 # so the version-resolver here is unused. The workflow overrides

--- a/.github/rulesets/block-release-publishing.json
+++ b/.github/rulesets/block-release-publishing.json
@@ -1,0 +1,34 @@
+{
+  "name": "Block release publishing",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~ALL"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 247347,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/default-protection.json
+++ b/.github/rulesets/default-protection.json
@@ -1,0 +1,61 @@
+{
+  "name": "Default protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    },
+    {
+      "type": "copilot_code_review",
+      "parameters": {
+        "review_on_push": false,
+        "review_draft_pull_requests": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 247347,
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     workflows: ["Release Drafter"]
     types: [completed]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && 'release-drafter' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -52,6 +55,10 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      # Draft releases are only visible to tokens with push access, so
+      # reading the draft requires contents: write despite being read-only.
+      contents: write
     outputs:
       version: ${{ steps.info.outputs.version }}
       summary: ${{ steps.info.outputs.summary }}
@@ -145,6 +152,8 @@ jobs:
       - build-firmware
       - determine-version
       - clean-draft-assets
+    permissions:
+      contents: write
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
       version: ${{ needs.determine-version.outputs.version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,197 +7,22 @@ on:
     workflows: ["Release Drafter"]
     types: [completed]
 
+# The called workflow's draft-release jobs (read draft info, replace assets,
+# strip the pending warning) need contents: write; they only run on
+# workflow_run events. Fork pull requests still get a read-only token.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && 'release-drafter' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  discover-files:
-    name: Discover Factory Configs
-    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    outputs:
-      files: ${{ steps.find.outputs.files }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: Find factory configs
-        id: find
-        run: |
-          set -euo pipefail
-          # By convention every device ships a <device>/<device>.factory.yaml;
-          # anything matching *.factory.yaml outside hidden directories is
-          # built. Prune dot-directories (.git, .github) rather than just
-          # filtering them from the results, so find never descends into them.
-          files=$(find . -path '*/.*' -prune -o -name '*.factory.yaml' -print | sed 's|^\./||' | sort)
-          if [[ -z "${files}" ]]; then
-            echo "::error::No *.factory.yaml files found"
-            exit 1
-          fi
-          echo "Discovered factory configs:"
-          echo "${files}"
-          {
-            echo "files<<FACTORY_FILES_EOF"
-            echo "${files}"
-            echo "FACTORY_FILES_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-  determine-version:
-    name: Determine Version
-    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
-    if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      # Draft releases are only visible to tokens with push access, so
-      # reading the draft requires contents: write despite being read-only.
-      contents: write
-    outputs:
-      version: ${{ steps.info.outputs.version }}
-      summary: ${{ steps.info.outputs.summary }}
-      url: ${{ steps.info.outputs.url }}
-    steps:
-      - name: Look up draft release info
-        id: info
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tag=""
-          url=""
-          body=""
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            # Ignore drafts whose tag was reset to an untagged-* placeholder
-            # (a stray PATCH without tag_name causes this) — building against
-            # one would bake the placeholder into the firmware as its version.
-            release_json=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first')
-            if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
-              echo "::error::No draft release found"
-              exit 1
-            fi
-            tag=$(echo "${release_json}" | jq -r '.tag_name')
-            url=$(echo "${release_json}" | jq -r '.html_url')
-            # Strip the ASSETS_PENDING caution block from the draft body before
-            # baking it into the firmware as release-summary; the warning is
-            # only meant for the maintainer viewing the draft on GitHub.
-            body=$(echo "${release_json}" | jq -r '.body' \
-              | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
-              | sed 's/<!-- ASSETS_PENDING -->//g' \
-              | sed '/./,$!d')
-          fi
-          echo "version=${tag}" >> "$GITHUB_OUTPUT"
-          echo "url=${url}" >> "$GITHUB_OUTPUT"
-          {
-            echo "summary<<RELEASE_SUMMARY_EOF"
-            echo "${body}"
-            echo "RELEASE_SUMMARY_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-  build-firmware:
-    name: Build Firmware
-    needs:
-      - discover-files
-      - determine-version
-    uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+  build:
+    name: Build to Draft Release
+    # Discovers *.factory.yaml configs, builds them, and — when triggered by
+    # a successful Release Drafter run — uploads the firmware to the current
+    # draft release. On pull_request/workflow_dispatch it only builds.
+    uses: esphome/workflows/.github/workflows/build-to-draft-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
-      files: ${{ needs.discover-files.outputs.files }}
-      esphome-version: 2026.6.4
-      release-summary: ${{ needs.determine-version.outputs.summary }}
-      release-url: ${{ needs.determine-version.outputs.url }}
-      release-version: ${{ needs.determine-version.outputs.version }}
-
-  clean-draft-assets:
-    name: Clean Draft Release Assets
-    # Delete any pre-existing assets so renamed files (e.g. when the version
-    # bumps from .1 to .2) don't linger alongside the new ones. Gated on
-    # build success so a failed build doesn't leave the draft release empty.
-    if: github.event_name == 'workflow_run'
-    needs:
-      - build-firmware
-      - determine-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Delete existing assets from draft release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tag="${{ needs.determine-version.outputs.version }}"
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
-          if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "Draft release ${tag} not found; nothing to clean"
-            exit 0
-          fi
-          release_id=$(echo "${release}" | jq -r '.id')
-          asset_ids=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --jq '.[].id')
-          for id in ${asset_ids}; do
-            echo "Deleting asset ${id}"
-            gh api "repos/${{ github.repository }}/releases/assets/${id}" \
-              --method DELETE --silent
-          done
-
-  upload-to-draft-release:
-    name: Upload to Draft Release
-    if: github.event_name == 'workflow_run'
-    needs:
-      - build-firmware
-      - determine-version
-      - clean-draft-assets
-    permissions:
-      contents: write
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      version: ${{ needs.determine-version.outputs.version }}
-      draft: true
-
-  remove-pending-warning:
-    name: Remove Pending Warning
-    if: github.event_name == 'workflow_run'
-    needs:
-      - upload-to-draft-release
-      - determine-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Remove ASSETS_PENDING warning from draft release body
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          tag="${{ needs.determine-version.outputs.version }}"
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
-          if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "Draft release ${tag} not found; nothing to clean up"
-            exit 0
-          fi
-          release_id=$(echo "${release}" | jq -r '.id')
-          body=$(echo "${release}" | jq -r '.body')
-          new_body=$(echo "${body}" \
-            | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
-            | sed 's/<!-- ASSETS_PENDING -->//g' \
-            | sed '/./,$!d')
-          if [[ "${new_body}" != "${body}" ]]; then
-            # tag_name and name must be re-sent: updating a draft release
-            # without them resets its tag to an untagged-* placeholder.
-            gh api "repos/${{ github.repository }}/releases/${release_id}" \
-              --method PATCH \
-              --field "body=${new_body}" \
-              --field "tag_name=${tag}" \
-              --field "name=${tag}" \
-              --field "draft=true" \
-              --silent
-          fi
+      esphome-version: 2026.7.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,61 +1,187 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release Drafter"]
+    types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_run' && 'release-drafter' || github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  discover-files:
+    name: Discover Factory Configs
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      files: ${{ steps.find.outputs.files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Find factory configs
+        id: find
+        run: |
+          set -euo pipefail
+          # By convention every device ships a <device>/<device>.factory.yaml;
+          # anything matching *.factory.yaml outside hidden directories is
+          # built. Prune dot-directories (.git, .github) rather than just
+          # filtering them from the results, so find never descends into them.
+          files=$(find . -path '*/.*' -prune -o -name '*.factory.yaml' -print | sed 's|^\./||' | sort)
+          if [[ -z "${files}" ]]; then
+            echo "::error::No *.factory.yaml files found"
+            exit 1
+          fi
+          echo "Discovered factory configs:"
+          echo "${files}"
+          {
+            echo "files<<FACTORY_FILES_EOF"
+            echo "${files}"
+            echo "FACTORY_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  determine-version:
+    name: Determine Version
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      summary: ${{ steps.info.outputs.summary }}
+      url: ${{ steps.info.outputs.url }}
+    steps:
+      - name: Look up draft release info
+        id: info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag=""
+          url=""
+          body=""
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            release_json=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[] | select(.draft == true)] | first')
+            if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
+              echo "::error::No draft release found"
+              exit 1
+            fi
+            tag=$(echo "${release_json}" | jq -r '.tag_name')
+            url=$(echo "${release_json}" | jq -r '.html_url')
+            # Strip the ASSETS_PENDING caution block from the draft body before
+            # baking it into the firmware as release-summary; the warning is
+            # only meant for the maintainer viewing the draft on GitHub.
+            body=$(echo "${release_json}" | jq -r '.body' \
+              | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+              | sed 's/<!-- ASSETS_PENDING -->//g' \
+              | sed '/./,$!d')
+          fi
+          echo "version=${tag}" >> "$GITHUB_OUTPUT"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<RELEASE_SUMMARY_EOF"
+            echo "${body}"
+            echo "RELEASE_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
   build-firmware:
     name: Build Firmware
+    needs:
+      - discover-files
+      - determine-version
     uses: esphome/workflows/.github/workflows/build.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
     with:
-      files: |
-        m5stack/m5stack-atom-echo.factory.yaml
-        m5stack/m5stack-atom-speaker-kit.factory.yaml
-        onju-voice/onju-voice.factory.yaml
-        raspiaudio/raspiaudio-muse-luxe.factory.yaml
-        raspiaudio/raspiaudio-muse-proto.factory.yaml
+      files: ${{ needs.discover-files.outputs.files }}
       esphome-version: 2026.6.4
-      release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
-      release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
-      release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+      release-summary: ${{ needs.determine-version.outputs.summary }}
+      release-url: ${{ needs.determine-version.outputs.url }}
+      release-version: ${{ needs.determine-version.outputs.version }}
 
-  upload-to-r2:
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
-    name: Upload to R2
+  clean-draft-assets:
+    name: Clean Draft Release Assets
+    # Delete any pre-existing assets so renamed files (e.g. when the version
+    # bumps from .1 to .2) don't linger alongside the new ones. Gated on
+    # build success so a failed build doesn't leave the draft release empty.
+    if: github.event_name == 'workflow_run'
     needs:
       - build-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      directory: media-player
-    secrets: inherit
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete existing assets from draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.determine-version.outputs.version }}"
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${tag} not found; nothing to clean"
+            exit 0
+          fi
+          release_id=$(echo "${release}" | jq -r '.id')
+          asset_ids=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --jq '.[].id')
+          for id in ${asset_ids}; do
+            echo "Deleting asset ${id}"
+            gh api "repos/${{ github.repository }}/releases/assets/${id}" \
+              --method DELETE --silent
+          done
 
-  upload-to-release:
-    name: Upload to Release
-    if: github.event_name == 'release'
+  upload-to-draft-release:
+    name: Upload to Draft Release
+    if: github.event_name == 'workflow_run'
+    needs:
+      - build-firmware
+      - determine-version
+      - clean-draft-assets
     uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    needs:
-      - build-firmware
     with:
-      version: ${{ github.event.release.tag_name }}
+      version: ${{ needs.determine-version.outputs.version }}
+      draft: true
 
-  promote-prod:
-    name: Promote to Production
-    if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+  remove-pending-warning:
+    name: Remove Pending Warning
+    if: github.event_name == 'workflow_run'
     needs:
-      - upload-to-r2
-    with:
-      version: ${{ github.event.release.tag_name }}
-      directory: media-player
-      channel: production
-    secrets: inherit
+      - upload-to-draft-release
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Remove ASSETS_PENDING warning from draft release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.determine-version.outputs.version }}"
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${tag} not found; nothing to clean up"
+            exit 0
+          fi
+          release_id=$(echo "${release}" | jq -r '.id')
+          body=$(echo "${release}" | jq -r '.body')
+          new_body=$(echo "${body}" \
+            | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+            | sed 's/<!-- ASSETS_PENDING -->//g' \
+            | sed '/./,$!d')
+          if [[ "${new_body}" != "${body}" ]]; then
+            gh api "repos/${{ github.repository }}/releases/${release_id}" \
+              --method PATCH \
+              --field "body=${new_body}" \
+              --field "draft=true" \
+              --silent
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,11 @@ jobs:
           url=""
           body=""
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — building against
+            # one would bake the placeholder into the firmware as its version.
             release_json=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true)] | first')
+              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first')
             if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
               echo "::error::No draft release found"
               exit 1
@@ -188,9 +191,13 @@ jobs:
             | sed 's/<!-- ASSETS_PENDING -->//g' \
             | sed '/./,$!d')
           if [[ "${new_body}" != "${body}" ]]; then
+            # tag_name and name must be re-sent: updating a draft release
+            # without them resets its tag to an untagged-* placeholder.
             gh api "repos/${{ github.repository }}/releases/${release_id}" \
               --method PATCH \
               --field "body=${new_body}" \
+              --field "tag_name=${tag}" \
+              --field "name=${tag}" \
               --field "draft=true" \
               --silent
           fi

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   lock:
-    uses: esphome/workflows/.github/workflows/lock.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    uses: esphome/workflows/.github/workflows/lock.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     with:
       pr-close-days: 1
       issue-close-days: 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,153 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  discover-devices:
+    name: Discover devices in release
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+      directory: ${{ steps.directory.outputs.directory }}
+    steps:
+      - name: Determine firmware directory
+        id: directory
+        env:
+          # Set a `FIRMWARE_DIRECTORY` repository variable to override the
+          # default, which is the repository name singularized
+          # (e.g. rf-proxies -> rf-proxy, media-players -> media-player).
+          # This is the directory used on https://firmware.esphome.io/ and
+          # must match the `update.source` URLs in the factory YAML files.
+          OVERRIDE: ${{ vars.FIRMWARE_DIRECTORY }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          set -euo pipefail
+          directory="${OVERRIDE}"
+          if [[ -z "${directory}" ]]; then
+            if [[ "${REPO_NAME}" == *ies ]]; then
+              directory="${REPO_NAME%ies}y"
+            else
+              directory="${REPO_NAME%s}"
+            fi
+          fi
+          echo "directory=${directory}" >> "$GITHUB_OUTPUT"
+          echo "Firmware directory: ${directory}"
+
+      - name: List devices from release manifests
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p manifests
+          gh release download "${{ github.event.release.tag_name }}" \
+            --repo "${{ github.repository }}" \
+            --dir manifests \
+            --pattern '*.manifest.json'
+          devices=$(ls manifests | sed 's/\.manifest\.json$//' \
+            | jq -R -s 'split("\n") | map(select(length > 0))')
+          if [[ "$(echo "${devices}" | jq 'length')" -eq 0 ]]; then
+            echo "::error::No <device>.manifest.json assets found on release"
+            exit 1
+          fi
+          echo "matrix=$(jq -c -n --argjson devices "${devices}" '{device: $devices}')" >> "$GITHUB_OUTPUT"
+          echo "Discovered devices: ${devices}"
+
+  prepare-artifact:
+    name: Prepare ${{ matrix.device }} artifact
+    needs: discover-devices
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-devices.outputs.matrix) }}
+    steps:
+      - name: Download device assets and reconstruct layout
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEVICE: ${{ matrix.device }}
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # Recreate the `<version>/{manifest.json,*.bin}` layout that
+          # upload-to-r2 / promote-r2 expect from a build.yml run. The
+          # artifact name (= device) becomes the surrounding directory when
+          # download-artifact runs in the reusable workflows.
+          target="output/${VERSION}"
+          mkdir -p "${target}"
+
+          # Pull just this device's manifest first so we know which
+          # binaries to fetch — avoids each matrix runner re-downloading
+          # every other device's bins.
+          gh release download "${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --dir "${target}" \
+            --pattern "${DEVICE}.manifest.json"
+          mv "${target}/${DEVICE}.manifest.json" "${target}/manifest.json"
+
+          # Build a multi-pattern download for the bins the manifest
+          # references (ota + parts), then run a single gh call.
+          patterns=()
+          while IFS= read -r bin; do
+            [[ -z "${bin}" ]] && continue
+            patterns+=(--pattern "${bin}")
+          done < <(jq -r '[
+            (.builds[]?.ota.path // empty),
+            (.builds[]?.parts[]?.path // empty)
+          ] | unique | .[]' "${target}/manifest.json")
+
+          if [[ "${#patterns[@]}" -gt 0 ]]; then
+            gh release download "${VERSION}" \
+              --repo "${{ github.repository }}" \
+              --dir "${target}" \
+              "${patterns[@]}"
+          fi
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.device }}
+          path: output
+          if-no-files-found: error
+
+  upload-to-r2:
+    name: Upload to R2
+    needs:
+      - discover-devices
+      - prepare-artifact
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      directory: ${{ needs.discover-devices.outputs.directory }}
+    secrets: inherit
+
+  promote-beta:
+    name: Promote to Beta
+    needs:
+      - discover-devices
+      - upload-to-r2
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      version: ${{ github.event.release.tag_name }}
+      directory: ${{ needs.discover-devices.outputs.directory }}
+      channel: beta
+      manifest-filename: manifest-beta.json
+    secrets: inherit
+
+  promote-prod:
+    name: Promote to Production
+    if: github.event.release.prerelease == false
+    needs:
+      - discover-devices
+      - upload-to-r2
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
+    with:
+      version: ${{ github.event.release.tag_name }}
+      directory: ${{ needs.discover-devices.outputs.directory }}
+      channel: production
+      manifest-filename: manifest.json
+    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,10 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
+# Jobs that download release assets request contents: read individually; the
+# upload/promote jobs only use the Cloudflare R2 secrets and never touch
+# GITHUB_TOKEN, so they run with no permissions at all.
+permissions: {}
 
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
@@ -15,6 +17,9 @@ jobs:
   discover-devices:
     name: Discover devices in release
     runs-on: ubuntu-latest
+    permissions:
+      # Read release assets with gh release download.
+      contents: read
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
       directory: ${{ steps.directory.outputs.directory }}
@@ -66,6 +71,9 @@ jobs:
     name: Prepare ${{ matrix.device }} artifact
     needs: discover-devices
     runs-on: ubuntu-latest
+    permissions:
+      # Read release assets with gh release download.
+      contents: read
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.discover-devices.outputs.matrix) }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,161 +4,20 @@ on:
   release:
     types: [published]
 
-# Jobs that download release assets request contents: read individually; the
-# upload/promote jobs only use the Cloudflare R2 secrets and never touch
-# GITHUB_TOKEN, so they run with no permissions at all.
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: publish-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 jobs:
-  discover-devices:
-    name: Discover devices in release
-    runs-on: ubuntu-latest
-    permissions:
-      # Read release assets with gh release download.
-      contents: read
-    outputs:
-      matrix: ${{ steps.find.outputs.matrix }}
-      directory: ${{ steps.directory.outputs.directory }}
-    steps:
-      - name: Determine firmware directory
-        id: directory
-        env:
-          # Set a `FIRMWARE_DIRECTORY` repository variable to override the
-          # default, which is the repository name singularized
-          # (e.g. rf-proxies -> rf-proxy, media-players -> media-player).
-          # This is the directory used on https://firmware.esphome.io/ and
-          # must match the `update.source` URLs in the factory YAML files.
-          OVERRIDE: ${{ vars.FIRMWARE_DIRECTORY }}
-          REPO_NAME: ${{ github.event.repository.name }}
-        run: |
-          set -euo pipefail
-          directory="${OVERRIDE}"
-          if [[ -z "${directory}" ]]; then
-            if [[ "${REPO_NAME}" == *ies ]]; then
-              directory="${REPO_NAME%ies}y"
-            else
-              directory="${REPO_NAME%s}"
-            fi
-          fi
-          echo "directory=${directory}" >> "$GITHUB_OUTPUT"
-          echo "Firmware directory: ${directory}"
-
-      - name: List devices from release manifests
-        id: find
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          mkdir -p manifests
-          gh release download "${{ github.event.release.tag_name }}" \
-            --repo "${{ github.repository }}" \
-            --dir manifests \
-            --pattern '*.manifest.json'
-          devices=$(ls manifests | sed 's/\.manifest\.json$//' \
-            | jq -R -s 'split("\n") | map(select(length > 0))')
-          if [[ "$(echo "${devices}" | jq 'length')" -eq 0 ]]; then
-            echo "::error::No <device>.manifest.json assets found on release"
-            exit 1
-          fi
-          echo "matrix=$(jq -c -n --argjson devices "${devices}" '{device: $devices}')" >> "$GITHUB_OUTPUT"
-          echo "Discovered devices: ${devices}"
-
-  prepare-artifact:
-    name: Prepare ${{ matrix.device }} artifact
-    needs: discover-devices
-    runs-on: ubuntu-latest
-    permissions:
-      # Read release assets with gh release download.
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.discover-devices.outputs.matrix) }}
-    steps:
-      - name: Download device assets and reconstruct layout
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEVICE: ${{ matrix.device }}
-          VERSION: ${{ github.event.release.tag_name }}
-        run: |
-          set -euo pipefail
-          # Recreate the `<version>/{manifest.json,*.bin}` layout that
-          # upload-to-r2 / promote-r2 expect from a build.yml run. The
-          # artifact name (= device) becomes the surrounding directory when
-          # download-artifact runs in the reusable workflows.
-          target="output/${VERSION}"
-          mkdir -p "${target}"
-
-          # Pull just this device's manifest first so we know which
-          # binaries to fetch — avoids each matrix runner re-downloading
-          # every other device's bins.
-          gh release download "${VERSION}" \
-            --repo "${{ github.repository }}" \
-            --dir "${target}" \
-            --pattern "${DEVICE}.manifest.json"
-          mv "${target}/${DEVICE}.manifest.json" "${target}/manifest.json"
-
-          # Build a multi-pattern download for the bins the manifest
-          # references (ota + parts), then run a single gh call.
-          patterns=()
-          while IFS= read -r bin; do
-            [[ -z "${bin}" ]] && continue
-            patterns+=(--pattern "${bin}")
-          done < <(jq -r '[
-            (.builds[]?.ota.path // empty),
-            (.builds[]?.parts[]?.path // empty)
-          ] | unique | .[]' "${target}/manifest.json")
-
-          if [[ "${#patterns[@]}" -gt 0 ]]; then
-            gh release download "${VERSION}" \
-              --repo "${{ github.repository }}" \
-              --dir "${target}" \
-              "${patterns[@]}"
-          fi
-
-      - name: Upload firmware artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: ${{ matrix.device }}
-          path: output
-          if-no-files-found: error
-
-  upload-to-r2:
-    name: Upload to R2
-    needs:
-      - discover-devices
-      - prepare-artifact
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      directory: ${{ needs.discover-devices.outputs.directory }}
-    secrets: inherit
-
-  promote-beta:
-    name: Promote to Beta
-    needs:
-      - discover-devices
-      - upload-to-r2
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      version: ${{ github.event.release.tag_name }}
-      directory: ${{ needs.discover-devices.outputs.directory }}
-      channel: beta
-      manifest-filename: manifest-beta.json
-    secrets: inherit
-
-  promote-prod:
-    name: Promote to Production
-    if: github.event.release.prerelease == false
-    needs:
-      - discover-devices
-      - upload-to-r2
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@025a1e6255610c498ed590403b7e510b69e474df  # 2026.4.1
-    with:
-      version: ${{ github.event.release.tag_name }}
-      directory: ${{ needs.discover-devices.outputs.directory }}
-      channel: production
-      manifest-filename: manifest.json
+  publish:
+    name: Publish firmware to R2
+    # Downloads the release's firmware assets and uploads them to
+    # https://firmware.esphome.io/ (beta always, production for
+    # non-prerelease). The firmware directory defaults to the repository
+    # name singularized (e.g. rf-proxies -> rf-proxy); set a
+    # FIRMWARE_DIRECTORY repository variable to override it.
+    uses: esphome/workflows/.github/workflows/publish-firmware-to-r2.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
     secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,63 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-drafter
+  cancel-in-progress: false
+
+jobs:
+  release-drafter:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate calver version
+        id: calver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # CalVer scheme: YY.M.N
+          #   YY = year mod 100 (e.g. 2026 -> 26)
+          #   M  = month, no zero padding (e.g. April -> 4)
+          #   N  = sequential release of that month, starting at 1
+          year=$(date -u +%y)
+          month=$(date -u +%-m)
+          prefix="${year}.${month}."
+
+          # Highest existing tag (draft or published) matching the current YY.M.*
+          latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | sub(\"^${prefix}\"; \"\") | tonumber] | max // 0")
+
+          if [[ "${latest_seq}" -eq 0 ]]; then
+            seq=1
+          else
+            # If the existing release at the highest seq is still a draft, reuse it
+            # so subsequent pushes update the same draft. Otherwise start a new one.
+            is_draft=$(gh api "repos/${{ github.repository }}/releases" --paginate \
+              --jq "[.[] | select(.tag_name == \"${prefix}${latest_seq}\")] | first | .draft")
+            if [[ "${is_draft}" == "true" ]]; then
+              seq=${latest_seq}
+            else
+              seq=$((latest_seq + 1))
+            fi
+          fi
+
+          version="${prefix}${seq}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Calculated calver version: ${version}"
+
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1
+        with:
+          version: ${{ steps.calver.outputs.version }}
+          tag: ${{ steps.calver.outputs.version }}
+          name: ${{ steps.calver.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -34,7 +34,7 @@ jobs:
 
           # Highest existing tag (draft or published) matching the current YY.M.*
           latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | sub(\"^${prefix}\"; \"\") | tonumber] | max // 0")
+            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | ltrimstr(\"${prefix}\") | tonumber] | max // 0")
 
           if [[ "${latest_seq}" -eq 0 ]]; then
             seq=1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,48 +16,7 @@ concurrency:
 jobs:
   release-drafter:
     name: Update draft release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Calculate calver version
-        id: calver
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          # CalVer scheme: YY.M.N
-          #   YY = year mod 100 (e.g. 2026 -> 26)
-          #   M  = month, no zero padding (e.g. April -> 4)
-          #   N  = sequential release of that month, starting at 1
-          year=$(date -u +%y)
-          month=$(date -u +%-m)
-          prefix="${year}.${month}."
-
-          # Highest existing tag (draft or published) matching the current YY.M.*
-          latest_seq=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-            --jq "[.[] | select(.tag_name | startswith(\"${prefix}\")) | .tag_name | ltrimstr(\"${prefix}\") | tonumber] | max // 0")
-
-          if [[ "${latest_seq}" -eq 0 ]]; then
-            seq=1
-          else
-            # If the existing release at the highest seq is still a draft, reuse it
-            # so subsequent pushes update the same draft. Otherwise start a new one.
-            is_draft=$(gh api "repos/${{ github.repository }}/releases" --paginate \
-              --jq "[.[] | select(.tag_name == \"${prefix}${latest_seq}\")] | first | .draft")
-            if [[ "${is_draft}" == "true" ]]; then
-              seq=${latest_seq}
-            else
-              seq=$((latest_seq + 1))
-            fi
-          fi
-
-          version="${prefix}${seq}"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Calculated calver version: ${version}"
-
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1
-        with:
-          version: ${{ steps.calver.outputs.version }}
-          tag: ${{ steps.calver.outputs.version }}
-          name: ${{ steps.calver.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Computes the next CalVer version (YY.M.N, reusing the current draft's
+    # sequence number) and runs release-drafter with it. Reads this repo's
+    # .github/release-drafter.yml for the changelog categories.
+    uses: esphome/workflows/.github/workflows/draft-calver-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (defaults to the most recent draft)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ inputs.tag || 'latest-draft' }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Patch manifests and publish
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      # We use a GitHub App token (not GITHUB_TOKEN) so that publishing the
+      # release fires a `release: published` event downstream — the default
+      # GITHUB_TOKEN intentionally does not trigger further workflows, which
+      # would leave publish.yml dormant.
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Resolve draft release
+        id: find
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG}"
+          if [[ -z "${tag}" ]]; then
+            tag=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[] | select(.draft == true)] | first | .tag_name // ""')
+          fi
+          if [[ -z "${tag}" || "${tag}" == "null" ]]; then
+            echo "::error::No draft release found"
+            exit 1
+          fi
+          release=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "::error::Draft release ${tag} not found"
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "release_id=$(echo "${release}" | jq -r '.id')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "${release}" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            echo "${release}" | jq -r '.body'
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved draft release: ${tag}"
+
+      - name: Download manifest assets
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          gh release download "${{ steps.find.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --dir assets \
+            --pattern '*.manifest.json'
+
+      - name: Patch manifests with current release body
+        env:
+          RELEASE_SUMMARY: ${{ steps.find.outputs.body }}
+          RELEASE_URL: ${{ steps.find.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p patched
+          for manifest in assets/*.manifest.json; do
+            jq --arg summary "${RELEASE_SUMMARY}" --arg url "${RELEASE_URL}" \
+              '.builds[].ota |= (.summary = $summary | .release_url = $url)' \
+              "${manifest}" > "patched/$(basename "${manifest}")"
+          done
+
+      - name: Re-upload patched manifests to draft release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ steps.find.outputs.tag }}"
+          for manifest in patched/*.manifest.json; do
+            echo "Replacing ${manifest}"
+            gh release upload "${tag}" "${manifest}" \
+              --repo "${{ github.repository }}" \
+              --clobber
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          gh release edit "${{ steps.find.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false
+          echo "Published ${{ steps.find.outputs.tag }} — publish.yml will pick it up via release: published"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,11 @@ jobs:
           set -euo pipefail
           tag="${INPUT_TAG}"
           if [[ -z "${tag}" ]]; then
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — publishing one
+            # would create a release under the placeholder tag.
             tag=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true)] | first | .tag_name // ""')
+              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first | .tag_name // ""')
           fi
           if [[ -z "${tag}" || "${tag}" == "null" ]]; then
             echo "::error::No draft release found"
@@ -74,10 +77,27 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p assets
-          gh release download "${{ steps.find.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --dir assets \
-            --pattern '*.manifest.json'
+          # Work with the release id resolved above instead of `gh release
+          # download <tag>`: gh's draft-by-tag resolution has proven
+          # unreliable (it caused duplicate drafts in esphome/workflows'
+          # upload-to-gh-release.yml), while lookups by id always work.
+          release_id="${{ steps.find.outputs.release_id }}"
+          if ! assets=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --paginate \
+            --jq '.[] | select(.name | endswith(".manifest.json")) | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
+          if [[ -z "${assets}" ]]; then
+            echo "::error::No *.manifest.json assets found on draft release"
+            exit 1
+          fi
+          while IFS=$'\t' read -r asset_id asset_name; do
+            echo "Downloading ${asset_name}"
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${{ github.repository }}/releases/assets/${asset_id}" \
+              > "assets/${asset_name}"
+          done <<< "${assets}"
 
       - name: Patch manifests with current release body
         env:
@@ -97,12 +117,30 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
-          tag="${{ steps.find.outputs.tag }}"
+          # Upload by release id rather than `gh release upload <tag>
+          # --clobber` for the same reason as the download step: draft-by-tag
+          # resolution is unreliable. Clobber semantics are replicated by
+          # deleting any same-named asset before uploading.
+          release_id="${{ steps.find.outputs.release_id }}"
+          if ! existing=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
+            --paginate \
+            --jq '.[] | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
           for manifest in patched/*.manifest.json; do
-            echo "Replacing ${manifest}"
-            gh release upload "${tag}" "${manifest}" \
-              --repo "${{ github.repository }}" \
-              --clobber
+            name=$(basename "${manifest}")
+            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1}' <<< "${existing}")
+            if [[ -n "${asset_id}" ]]; then
+              echo "Deleting existing asset ${name} (${asset_id})"
+              gh api "repos/${{ github.repository }}/releases/assets/${asset_id}" \
+                --method DELETE --silent
+            fi
+            echo "Uploading ${name}"
+            gh api --method POST \
+              -H "Content-Type: application/json" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${release_id}/assets?name=${name}" \
+              --input "${manifest}" --silent
           done
 
       - name: Publish release
@@ -110,7 +148,16 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           set -euo pipefail
-          gh release edit "${{ steps.find.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --draft=false
-          echo "Published ${{ steps.find.outputs.tag }} — publish.yml will pick it up via release: published"
+          tag="${{ steps.find.outputs.tag }}"
+          # Publish by id, not `gh release edit <tag> --draft=false`: besides
+          # the unreliable draft-by-tag resolution, gh sends a PATCH with only
+          # draft=false — and updating a draft without re-sending tag_name
+          # resets its tag to an untagged-* placeholder, which would then be
+          # published as the release tag.
+          gh api "repos/${{ github.repository }}/releases/${{ steps.find.outputs.release_id }}" \
+            --method PATCH \
+            --field "tag_name=${tag}" \
+            --field "name=${tag}" \
+            --field "draft=false" \
+            --silent
+          echo "Published ${tag} — publish.yml will pick it up via release: published"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,156 +8,20 @@ on:
         required: false
         type: string
 
-# Every step authenticates with the ESPHome GitHub App token (see the
-# comment on the first step); the default GITHUB_TOKEN is never used.
+# The called workflow authenticates every step with the ESPHome GitHub App
+# token (via vars.ESPHOME_GITHUB_APP_CLIENT_ID and the inherited
+# ESPHOME_GITHUB_APP_PRIVATE_KEY secret) so that publishing fires a
+# `release: published` event downstream; GITHUB_TOKEN is never used. It also
+# runs in this repo's `release` environment.
 permissions: {}
-
-concurrency:
-  group: release-${{ inputs.tag || 'latest-draft' }}
-  cancel-in-progress: false
 
 jobs:
   release:
-    name: Patch manifests and publish
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      # We use a GitHub App token (not GITHUB_TOKEN) so that publishing the
-      # release fires a `release: published` event downstream — the default
-      # GITHUB_TOKEN intentionally does not trigger further workflows, which
-      # would leave publish.yml dormant.
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
-        with:
-          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
-          # Scope the token to what this job does: read the draft release,
-          # replace its manifest assets and publish it.
-          permission-contents: write
-
-      - name: Resolve draft release
-        id: find
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          tag="${INPUT_TAG}"
-          if [[ -z "${tag}" ]]; then
-            # Ignore drafts whose tag was reset to an untagged-* placeholder
-            # (a stray PATCH without tag_name causes this) — publishing one
-            # would create a release under the placeholder tag.
-            tag=$(gh api "repos/${{ github.repository }}/releases" \
-              --jq '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first | .tag_name // ""')
-          fi
-          if [[ -z "${tag}" || "${tag}" == "null" ]]; then
-            echo "::error::No draft release found"
-            exit 1
-          fi
-          release=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq "[.[] | select(.tag_name == \"${tag}\" and .draft == true)] | first")
-          if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "::error::Draft release ${tag} not found"
-            exit 1
-          fi
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "release_id=$(echo "${release}" | jq -r '.id')" >> "$GITHUB_OUTPUT"
-          echo "url=$(echo "${release}" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
-          {
-            echo "body<<RELEASE_BODY_EOF"
-            echo "${release}" | jq -r '.body'
-            echo "RELEASE_BODY_EOF"
-          } >> "$GITHUB_OUTPUT"
-          echo "Resolved draft release: ${tag}"
-
-      - name: Download manifest assets
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          mkdir -p assets
-          # Work with the release id resolved above instead of `gh release
-          # download <tag>`: gh's draft-by-tag resolution has proven
-          # unreliable (it caused duplicate drafts in esphome/workflows'
-          # upload-to-gh-release.yml), while lookups by id always work.
-          release_id="${{ steps.find.outputs.release_id }}"
-          if ! assets=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --paginate \
-            --jq '.[] | select(.name | endswith(".manifest.json")) | "\(.id)\t\(.name)"'); then
-            echo "::error::Failed to list draft release assets"
-            exit 1
-          fi
-          if [[ -z "${assets}" ]]; then
-            echo "::error::No *.manifest.json assets found on draft release"
-            exit 1
-          fi
-          while IFS=$'\t' read -r asset_id asset_name; do
-            echo "Downloading ${asset_name}"
-            gh api -H "Accept: application/octet-stream" \
-              "repos/${{ github.repository }}/releases/assets/${asset_id}" \
-              > "assets/${asset_name}"
-          done <<< "${assets}"
-
-      - name: Patch manifests with current release body
-        env:
-          RELEASE_SUMMARY: ${{ steps.find.outputs.body }}
-          RELEASE_URL: ${{ steps.find.outputs.url }}
-        run: |
-          set -euo pipefail
-          mkdir -p patched
-          for manifest in assets/*.manifest.json; do
-            jq --arg summary "${RELEASE_SUMMARY}" --arg url "${RELEASE_URL}" \
-              '.builds[].ota |= (.summary = $summary | .release_url = $url)' \
-              "${manifest}" > "patched/$(basename "${manifest}")"
-          done
-
-      - name: Re-upload patched manifests to draft release
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          # Upload by release id rather than `gh release upload <tag>
-          # --clobber` for the same reason as the download step: draft-by-tag
-          # resolution is unreliable. Clobber semantics are replicated by
-          # deleting any same-named asset before uploading.
-          release_id="${{ steps.find.outputs.release_id }}"
-          if ! existing=$(gh api "repos/${{ github.repository }}/releases/${release_id}/assets" \
-            --paginate \
-            --jq '.[] | "\(.id)\t\(.name)"'); then
-            echo "::error::Failed to list draft release assets"
-            exit 1
-          fi
-          for manifest in patched/*.manifest.json; do
-            name=$(basename "${manifest}")
-            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1}' <<< "${existing}")
-            if [[ -n "${asset_id}" ]]; then
-              echo "Deleting existing asset ${name} (${asset_id})"
-              gh api "repos/${{ github.repository }}/releases/assets/${asset_id}" \
-                --method DELETE --silent
-            fi
-            echo "Uploading ${name}"
-            gh api --method POST \
-              -H "Content-Type: application/json" \
-              "https://uploads.github.com/repos/${{ github.repository }}/releases/${release_id}/assets?name=${name}" \
-              --input "${manifest}" --silent
-          done
-
-      - name: Publish release
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          set -euo pipefail
-          tag="${{ steps.find.outputs.tag }}"
-          # Publish by id, not `gh release edit <tag> --draft=false`: besides
-          # the unreliable draft-by-tag resolution, gh sends a PATCH with only
-          # draft=false — and updating a draft without re-sending tag_name
-          # resets its tag to an untagged-* placeholder, which would then be
-          # published as the release tag.
-          gh api "repos/${{ github.repository }}/releases/${{ steps.find.outputs.release_id }}" \
-            --method PATCH \
-            --field "tag_name=${tag}" \
-            --field "name=${tag}" \
-            --field "draft=false" \
-            --silent
-          echo "Published ${tag} — publish.yml will pick it up via release: published"
+    name: Publish draft release
+    # Patches the draft release's manifest assets with the final release
+    # notes, then publishes it — all by release id, immune to the
+    # draft-by-tag lookup and draft-untagging API pitfalls.
+    uses: esphome/workflows/.github/workflows/publish-draft-release.yml@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,9 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
+# Every step authenticates with the ESPHome GitHub App token (see the
+# comment on the first step); the default GITHUB_TOKEN is never used.
+permissions: {}
 
 concurrency:
   group: release-${{ inputs.tag || 'latest-draft' }}
@@ -31,6 +32,9 @@ jobs:
         with:
           client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the token to what this job does: read the draft release,
+          # replace its manifest assets and publish it.
+          permission-contents: write
 
       - name: Resolve draft release
         id: find

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,8 +3,8 @@ on:
   schedule:
     - cron: '50 18 * * *'
 
-# Only issues are processed (no stale-pr-message is configured, so
-# actions/stale never marks pull requests), so no pull-requests scope.
+# Only issues are processed (days-before-pr-stale: -1 disables pull
+# request processing entirely), so no pull-requests scope.
 permissions:
   issues: write
 
@@ -17,6 +17,7 @@ jobs:
           stale-issue-message: 'As there has been no activity on this issue for 30 days, I am marking it as stale. If you think this is a mistake, please comment below and I will remove the stale label.'
           close-issue-message: 'This issue has been closed due to inactivity. If you think this is a mistake, please comment below.'
           days-before-stale: 30
+          days-before-pr-stale: -1
           days-before-close: 5
           stale-issue-label: 'stale'
           exempt-issue-labels: 'not-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: '50 18 * * *'
 
+# Only issues are processed (no stale-pr-message is configured, so
+# actions/stale never marks pull requests), so no pull-requests scope.
+permissions:
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008  # v10.1.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629  # v10.4.0
         with:
           stale-issue-message: 'As there has been no activity on this issue for 30 days, I am marking it as stale. If you think this is a mistake, please comment below and I will remove the stale label.'
           close-issue-message: 'This issue has been closed due to inactivity. If you think this is a mistake, please comment below.'

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -13,10 +13,10 @@ on:
 
 jobs:
   yamllint:
-    name: 🧹 yamllint
+    name: yamllint
     runs-on: ubuntu-latest
     steps:
-      - name: ⤵️ Check out configuration from GitHub
+      - name: Check out configuration from GitHub
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - name: 🚀 Run yamllint
+      - name: Run yamllint
         run: yamllint --strict .

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,6 +11,9 @@ on:
       - "**.yaml"
       - "**.yml"
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: yamllint

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Gitignore settings for ESPHome
-# This is an example and may include too much for your use-case.
-# You can modify this file to suit your needs.
 .esphome/
-/secrets.yaml
-venv
+.DS_Store
+secrets.yaml
+*/.gitignore
+!/.gitignore
+venv/
+.claude/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # ESPHome Media Players
 
-This repo hosts known, tested devices that can serve as media players to Home Assistant.
+This repo hosts YAML configurations for a curated selection of known, tested devices that can serve as media players for Home Assistant.
+
+If a device is not included here it may have a suitable configuration in the [ESPHome Device Configuration Repository](https://devices.esphome.io/).
+
+## Supported devices
+
+| Device                   | Configuration                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| M5Stack Atom Echo        | [m5stack/m5stack-atom-echo.yaml](m5stack/m5stack-atom-echo.yaml)               |
+| M5Stack Atom Speaker Kit | [m5stack/m5stack-atom-speaker-kit.yaml](m5stack/m5stack-atom-speaker-kit.yaml) |
+| Onju Voice               | [onju-voice/onju-voice.yaml](onju-voice/onju-voice.yaml)                       |
+| Raspiaudio Muse Luxe     | [raspiaudio/raspiaudio-muse-luxe.yaml](raspiaudio/raspiaudio-muse-luxe.yaml)   |
+| Raspiaudio Muse Proto    | [raspiaudio/raspiaudio-muse-proto.yaml](raspiaudio/raspiaudio-muse-proto.yaml) |


### PR DESCRIPTION
# What does this implement/fix?

Modernises this repository to match the [ready-made project template](https://github.com/esphome/ready-made-project-template):

- **CalVer draft-release publishing flow**: every push to `main` updates a `YY.M.N` draft release (`release-drafter.yml`) and rebuilds/attaches firmware assets to it (`build.yml` via `workflow_run`); manually dispatching `release.yml` patches the manifests with the final notes and publishes the draft; `publish.yml` then uploads to R2 and promotes to the `beta` channel (and `production` for non-prereleases). The firmware.esphome.io directory is derived at runtime (`media-players` → `media-player`, matching the existing `update.source` URLs).
- **Factory config auto-discovery**: `build.yml` now discovers every `*.factory.yaml` by convention instead of a hardcoded `files:` list (verified the discovery matches the previous five files exactly).
- **Repo hygiene from the template**: bug report / config issue templates (linking to `esphome/esphome` issues and the org-wide discussions board), pull request template, importable ruleset JSON docs, updated devcontainer (python 3.13, USB passthrough, gh CLI), defensive `.gitignore`, and README structure with a supported-devices table.
- Action pin bumps to match the template: `actions/stale` v10.4.0, `release-drafter` v7.5.1.

The ESPHome pin stays at 2026.6.4. `lock.yml`, `dependabot.yml` and `.yamllint` already matched the template and are untouched.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue) — label: `bugfix`
- [ ] New device (adds a configuration for a new device) — label: `new-device`
- [ ] Enhancement (non-breaking change which improves an existing configuration) — label: `enhancement`
- [ ] Breaking change (fix or change that alters existing behaviour, e.g. renamed entities or changed pins) — label: `breaking-change`
- [ ] Dependency update (actions, reusable workflows or ESPHome version) — label: `dependencies`
- [x] Other

**Related issue (if applicable):**

- fixes N/A

## Checklist

- [ ] The configuration compiles and has been tested on the actual device.
- [x] `yamllint --strict .` passes.

If a device configuration was added or renamed:

- [ ] The device directory contains both `<device>.yaml` (core config) and `<device>.factory.yaml` (factory wrapper).
- [ ] `dashboard_import.package_import_url` points to the core YAML in this repository.
- [ ] `update.source` points to the correct `https://firmware.esphome.io/<directory>/<device>/manifest.json` URL.
- [ ] The factory YAML is named `<device>.factory.yaml` so CI picks it up automatically.
- [ ] The device is listed in the dropdown in `.github/ISSUE_TEMPLATE/bug_report.yml`.
- [ ] The README is updated if it lists supported devices.